### PR TITLE
overwrite changelog (rather than write to stdout)

### DIFF
--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -48,6 +48,7 @@ type Config struct {
 	Cleanup      bool
 	Branch       string
 	ReleaseTime  time.Time
+	OutputPath   string
 }
 
 func (c *Config) Repo() (*git.Repository, error) {

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"path"
 	"time"
 
 	"github.com/OffchainLabs/unclog/changelog"
@@ -19,7 +21,11 @@ func parseArgs(args []string) (*changelog.Config, error) {
 	flags.BoolVar(&c.Cleanup, "cleanup", false, "Remove the changelog fragment files after generating the changelog")
 	flags.Parse(args)
 	if c.RepoPath == "" {
-		return c, fmt.Errorf("repo is required")
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("repo flag not set and can't get working directory from syscall, %w", err)
+		}
+		c.RepoPath = wd
 	}
 	if c.Tag == "" {
 		return c, fmt.Errorf("tag is required")
@@ -39,6 +45,9 @@ func Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(out)
+	clPath := path.Join(cfg.RepoPath, cfg.PreviousPath)
+	if err := os.WriteFile(clPath, []byte(out), 0644); err != nil {
+		return err
+	}
 	return nil
 }

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -18,6 +18,7 @@ func parseArgs(args []string) (*changelog.Config, error) {
 	flags.StringVar(&c.ChangesDir, "changelog-dir", "changelog", "Path to the directory containing changelog fragments for each commit")
 	flags.StringVar(&c.Tag, "tag", "", "New release tag (must already exist in repo)")
 	flags.StringVar(&c.PreviousPath, "prev", "CHANGELOG.md", "Path to current changelog in the repo. This will be pulled from HEAD")
+	flags.StringVar(&c.OutputPath, "output", "", "Path to file where merged output will be written (relative to the -repo flag). Defaults to the value of the -prev flag")
 	flags.BoolVar(&c.Cleanup, "cleanup", false, "Remove the changelog fragment files after generating the changelog")
 	flags.Parse(args)
 	if c.RepoPath == "" {
@@ -33,6 +34,9 @@ func parseArgs(args []string) (*changelog.Config, error) {
 	if c.PreviousPath == "" {
 		return c, fmt.Errorf("prev is required")
 	}
+	if c.OutputPath == "" {
+		c.OutputPath = c.PreviousPath
+	}
 	return c, nil
 }
 
@@ -45,7 +49,7 @@ func Run(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	clPath := path.Join(cfg.RepoPath, cfg.PreviousPath)
+	clPath := path.Join(cfg.RepoPath, cfg.OutputPath)
 	if err := os.WriteFile(clPath, []byte(out), 0644); err != nil {
 		return err
 	}


### PR DESCRIPTION
This streamlines things by minimizing the number of required arguments. 