### PR TITLE
switch to full release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,3 +17,19 @@ jobs:
         uses: ./.github/actions/build-unclog
         with:
           artifact-name: unclog # This is the 'release' artifact name
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+
+    - name: Build
+      shell: bash
+      run: go build -o unclog -v .
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: unclog
+        make_latest: "true"

--- a/log/kasey_inplace-overwrite.md
+++ b/log/kasey_inplace-overwrite.md
@@ -1,0 +1,7 @@
+### Added
+
+- `-output` flag to specify path to write merged changelog output.
+
+### Changed
+
+- Instead of writing the merged changelog to stdout, it will be written to the `-output` flag, which defaults to the path of the previous changelog.

--- a/log/kasey_release-action.md
+++ b/log/kasey_release-action.md
@@ -1,0 +1,7 @@
+### Added
+
+- Automatically create a release when a version tag is pushed.
+
+### Removed
+
+- Stop building artifacts on pull request merges. Consumers of unclog should use the released binary, which is more stable.


### PR DESCRIPTION
The previous approach of rebuilding artifacts periodically to cope with artifact expiration was rendered moot by the fact that the action to access an external artifact turned out to require an eplicit run-id, making it fragile (we'd have to bump this id every 90 days or so). Building a release on tag push is way more robust/stable.