### PR TITLE
Release build denoiser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,6 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v4
 
-    - name: build-unclog
-      uses: ./.github/actions/build-unclog
-      with:
-        artifact-name: unclog # This is the 'release' artifact name
-
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/log/kasey_release-build-denoiser.md
+++ b/log/kasey_release-build-denoiser.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- release action would re-run go setup and build steps. remove the build using the shared action.


### PR DESCRIPTION
The release build action has a bunch of errors in the logs that come from the composite action and explicit go build steps both trying to do the same thing. This removes the composite action step.