### PR TITLE
Handle reverted or deleted fragments

### DIFF
--- a/changelog/git.go
+++ b/changelog/git.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"path"
 	"regexp"
 	"strconv"
@@ -145,7 +146,8 @@ func cleanupFragments(cfg *Config, fragments []Fragment) error {
 	}
 	for _, f := range fragments {
 		if err := tree.Filesystem.Remove(path.Join(cfg.ChangesDir, f.Path)); err != nil {
-			return fmt.Errorf("could not remove changelog fragment %s: %w", f.Path, err)
+			// A changelog fragment might have been removed already and that's OK. This happens when a PR is reverted.
+			log.Printf("Skipping fragment: could not remove changelog fragment %s: %v", f.Path, err)
 		}
 	}
 	return nil

--- a/cmd/release/testdata/example-single-deleted.md
+++ b/cmd/release/testdata/example-single-deleted.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- This is a fix, but it might be deleted later!

--- a/log/pvl-reverted-pr-case.md
+++ b/log/pvl-reverted-pr-case.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Reverted PRs no longer cause unclog to fail when performing release cleanup


### PR DESCRIPTION
This PR allows for commits that revert PRs. During release cleanup, unclog expected all fragments to exist and would fail when it failed to delete a fragment that was already deleted by a prior commit. 

This PR:
- Detects deleted changelog fragments and
- Does not mention them in the notes and
- Does not attempt (and fail) to delete a fragment that was already deleted.
