### PR TITLE
support env var providing filenames space-delimited

### DIFF
--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -86,6 +86,9 @@ func checkFragments(envCfg *githubConf) error {
 	if len(filePaths) == 0 {
 		return fmt.Errorf("no fragments found in env var %s", envCfg.FragmentListingEnv)
 	}
+	if len(filePaths) == 1 {
+		filePaths = strings.Split(listBlob, " ")
+	}
 	for _, p := range filePaths {
 		b, err := os.ReadFile(p)
 		if err != nil {

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -82,12 +82,9 @@ func checkFragments(envCfg *githubConf) error {
 	if listBlob == "" {
 		return fmt.Errorf("no fragments found in env var %s", envCfg.FragmentListingEnv)
 	}
-	filePaths := strings.Split(listBlob, "\n")
+	filePaths := strings.Fields(listBlob)
 	if len(filePaths) == 0 {
 		return fmt.Errorf("no fragments found in env var %s", envCfg.FragmentListingEnv)
-	}
-	if len(filePaths) == 1 {
-		filePaths = strings.Split(listBlob, " ")
 	}
 	for _, p := range filePaths {
 		b, err := os.ReadFile(p)

--- a/log/kasey_support-spaces-in-env.md
+++ b/log/kasey_support-spaces-in-env.md
@@ -1,0 +1,2 @@
+### Fixed
+- support filenames in the env var specified by `-fragment-env` to be space delimited rather than newline only.


### PR DESCRIPTION
We seem to be experiencing 2 issues with this prysm PR: https://github.com/OffchainLabs/prysm/actions/runs/15212486484/job/42798978715

1) The github action is skipping a commit when comparing the upstream to the branch to find changelog files, so it is finding multiple.
2) The action is giving the list of file names as space separated, whereas the `unclog check` command expects them to only be newline separated.

This PR resolves the second issue, allowing the `check` subcommand to work in this CI flow where multiple changelog files are found.