### PR TITLE
add option to use commit instead of PR in unclog release

### DIFF
--- a/changelog/changelog.go
+++ b/changelog/changelog.go
@@ -49,6 +49,10 @@ func (c *RepoConfig) PrURL(pr int) string {
 	return "https://github.com/" + c.Owner + "/" + c.Repo + "/pull/" + strconv.Itoa(pr)
 }
 
+func (c *RepoConfig) CommitURL(hash string) string {
+	return "https://github.com/" + c.Owner + "/" + c.Repo + "/commit/" + hash
+}
+
 // UnclogConfig represents the structure of the .unclog.yaml file
 type UnclogConfig struct {
 	Sections []string `yaml:"sections"`
@@ -64,6 +68,7 @@ type Config struct {
 	Previous     Previous
 	RepoConfig   RepoConfig
 	Cleanup      bool
+	UseCommit    bool
 	Branch       string
 	ReleaseTime  time.Time
 	OutputPath   string
@@ -123,11 +128,14 @@ func NewPreviousChangelog(r io.Reader) (Previous, error) {
 // Each commit's changelog file can have entries in different sections, indicated by
 // the same section headers as the final changelog.
 // Merge all changelog bullet points into their respective sections.
-func mergeEntries(fragments []Fragment, repo *RepoConfig) map[string][]string {
+func mergeEntries(fragments []Fragment, repo *RepoConfig, useCommit bool) map[string][]string {
 	sections := make(map[string][]string)
 	for _, f := range fragments {
-		pr := f.Commit.prLink(repo)
-		csecs := ParseFragment(f.Lines, pr)
+		link := f.Commit.prLink(repo)
+		if useCommit {
+			link = f.Commit.commitLink(repo)
+		}
+		csecs := ParseFragment(f.Lines, link)
 		for k, v := range csecs {
 			sections[k] = append(sections[k], v...)
 		}
@@ -274,7 +282,7 @@ func Release(ctx context.Context, cfg *Config) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sections := mergeEntries(fragments, &cfg.RepoConfig)
+	sections := mergeEntries(fragments, &cfg.RepoConfig, cfg.UseCommit)
 	if cfg.Cleanup {
 		if err := cleanupFragments(cfg, fragments); err != nil {
 			return "", err
@@ -321,14 +329,14 @@ func parseSection(line string) string {
 	return sec[1]
 }
 
-var prLinkRE = regexp.MustCompile(`\[\[PR\]\]\(https:\/\/[^\)]+\)`)
+var bulletLinkRE = regexp.MustCompile(`\[\[(PR|commit)\]\]\(https:\/\/[^\)]+\)`)
 
 func parseBullet(line string, pr string) string {
 	trimmed := strings.TrimLeft(line, " ")
 	if !strings.HasPrefix(trimmed, "- ") {
 		return ""
 	}
-	if prLinkRE.Match([]byte(trimmed)) {
+	if bulletLinkRE.Match([]byte(trimmed)) {
 		return line
 	}
 	return strings.TrimRight(line, " .") + ". " + pr

--- a/changelog/changelog_test.go
+++ b/changelog/changelog_test.go
@@ -22,6 +22,24 @@ func TestParseBulletOverride(t *testing.T) {
 	}
 }
 
+func TestParseBulletCommitOverride(t *testing.T) {
+	// A bullet that already carries a commit link must be left untouched.
+	line := "- added override [[commit]](https://github.com/OffchainLabs/nitro/commit/abc123)"
+	res := parseBullet(line, "NOPE")
+	if line != res {
+		t.Error("parseBullet did not recognize the existing commit link")
+	}
+}
+
+func TestCommitURL(t *testing.T) {
+	repo := &RepoConfig{Owner: "OffchainLabs", Repo: "nitro"}
+	got := repo.CommitURL("abc123")
+	want := "https://github.com/OffchainLabs/nitro/commit/abc123"
+	if got != want {
+		t.Errorf("CommitURL = %q, want %q", got, want)
+	}
+}
+
 func TestSectionRe(t *testing.T) {
 	cases := []struct {
 		value string

--- a/changelog/changelog_test.go
+++ b/changelog/changelog_test.go
@@ -23,7 +23,7 @@ func TestParseBulletOverride(t *testing.T) {
 }
 
 func TestParseBulletCommitOverride(t *testing.T) {
-	// A bullet that already carries a commit link must be left untouched.
+	// Re-runs must not append a second link to a bullet that already has one.
 	line := "- added override [[commit]](https://github.com/OffchainLabs/nitro/commit/abc123)"
 	res := parseBullet(line, "NOPE")
 	if line != res {

--- a/changelog/git.go
+++ b/changelog/git.go
@@ -42,6 +42,10 @@ func (c Commit) prLink(repo *RepoConfig) string {
 	return "[[PR]](" + repo.PrURL(c.pr) + ")"
 }
 
+func (c Commit) commitLink(repo *RepoConfig) string {
+	return "[[commit]](" + repo.CommitURL(c.Id()) + ")"
+}
+
 func tagTimestamp(r *git.Repository, tag string) (time.Time, error) {
 	t, err := r.Tag(tag)
 	if err != nil {

--- a/cmd/release/inmem_test.go
+++ b/cmd/release/inmem_test.go
@@ -57,7 +57,7 @@ func commitAddTag(t *testing.T, repo *git.Repository, fp string, prNum int, ctim
 	}
 }
 
-func copyFileToRepoMerge(t *testing.T, repo *git.Repository, fname string, ctime time.Time, prNum int, prTitle string, tag string) {
+func copyFileToRepoMerge(t *testing.T, repo *git.Repository, fname string, ctime time.Time, prNum int, prTitle string, tag string) plumbing.Hash {
 	tdp := path.Join("testdata", fname)
 	clp := path.Join("changelog", fname)
 	fh, err := os.Open(tdp)
@@ -70,10 +70,10 @@ func copyFileToRepoMerge(t *testing.T, repo *git.Repository, fname string, ctime
 	defer outfh.Close()
 	_, err = io.Copy(outfh, fh)
 	requireNoError(t, err)
-	commitMergeTag(t, repo, clp, prNum, prTitle, ctime, tag)
+	return commitMergeTag(t, repo, clp, prNum, prTitle, ctime, tag)
 }
 
-func commitMergeTag(t *testing.T, repo *git.Repository, fp string, prNum int, prTitle string, ctime time.Time, tag string) {
+func commitMergeTag(t *testing.T, repo *git.Repository, fp string, prNum int, prTitle string, ctime time.Time, tag string) plumbing.Hash {
 	tree, err := repo.Worktree()
 	requireNoError(t, err)
 	_, err = tree.Add(fp)
@@ -115,6 +115,7 @@ func commitMergeTag(t *testing.T, repo *git.Repository, fp string, prNum int, pr
 		_, err = repo.CreateTag(tag, mergeHash, nil)
 		requireNoError(t, err)
 	}
+	return mergeHash
 }
 
 // deleteFileFromRepo simulates a PR which cleanly reverted another PR while using a changelog fragment in the "ignored" section.
@@ -308,6 +309,41 @@ func TestMergeCommits(t *testing.T) {
 	}
 	if !strings.Contains(merged, "/pull/2)") {
 		t.Error("expected merged output to contain PR link for #2")
+	}
+}
+
+// In the non-squash workflow each PR is a merge commit, so UseCommit should link to
+// that merge commit's hash rather than the PR.
+func TestMergeCommitsUseCommit(t *testing.T) {
+	repo, cfg, prevTime, prNum := setupTestRepo(t)
+	cfg.UseCommit = true
+	prNum++
+	h1 := copyFileToRepoMerge(t, repo, "example-single.md", prevTime.Add(time.Duration(prNum)*time.Minute), prNum, "Add single feature", "")
+	prNum++
+	h2 := copyFileToRepoMerge(t, repo, "example-multi.md", prevTime.Add(time.Duration(prNum)*time.Minute), prNum, "Add multi feature", "")
+	var last plumbing.Hash
+	_, err := repo.CreateTag(cfg.Tag, last, nil)
+	requireNoError(t, err)
+	merged, err := changelog.Release(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The carried-over previous body keeps its old PR links, so only assert on the
+	// newly generated section above it.
+	generated := merged
+	if idx := strings.Index(merged, "## ["+cfg.Previous.Version+"]"); idx >= 0 {
+		generated = merged[:idx]
+	}
+
+	for _, h := range []plumbing.Hash{h1, h2} {
+		want := fmt.Sprintf("[[commit]](https://github.com/OffchainLabs/prysm/commit/%s)", h.String())
+		if !strings.Contains(generated, want) {
+			t.Errorf("expected generated section to contain commit link %q", want)
+		}
+	}
+	if strings.Contains(generated, "/pull/") {
+		t.Error("expected no PR links in commit mode, but found one in the generated section")
 	}
 }
 

--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -33,6 +33,7 @@ func parseArgs(args []string) (c *changelog.Config, err error) {
 	flags.StringVar(&c.PreviousPath, "prev", "CHANGELOG.md", "Path to current changelog in the repo. This will be pulled from HEAD")
 	flags.StringVar(&c.OutputPath, "output", "", "Path to file where merged output will be written (relative to the -repo flag). Defaults to the value of the -prev flag")
 	flags.BoolVar(&c.Cleanup, "cleanup", false, "Remove the changelog fragment files after generating the changelog")
+	flags.BoolVar(&c.UseCommit, "use-commit", false, "Link changelog bullets to the commit hash (e.g. on the public repo) instead of the PR")
 	flags.Parse(args)
 	if c.RepoPath == "" {
 		wd, err := os.Getwd()

--- a/log/ibraga_use-commit-flag.md
+++ b/log/ibraga_use-commit-flag.md
@@ -1,0 +1,3 @@
+### Added
+
+- Add `-use-commit` flag to the `release` command to link changelog bullets to the commit hash


### PR DESCRIPTION
Added a `-use-commit` boolean flag to unclog release. When passed, changelog bullets link to the commit hash instead of the PR: [[PR]](https://github.com/OffchainLabs/nitro-private/pull/142) → [[commit]](https://github.com/OffchainLabs/nitro/commit/<hash>)

Instead of changelog file looking like:
```
- Some change here [[PR]](https://github.com/OffchainLabs/nitro-private/pull/1234) 
- Another update there [[PR]](https://github.com/OffchainLabs/nitro-private/pull/2345) 
```
it will look like
```
- Some change here [[commit]](https://github.com/OffchainLabs/nitro/commit/<hash>)
- Another update there [[commit]](https://github.com/OffchainLabs/nitro/commit/<hash>)
```

- cmd/release/main.go: new -use-commit flag.
- changelog/changelog.go: added Config.UseCommit, a RepoConfig.CommitURL(hash) builder, threaded the flag through mergeEntries to pick between prLink/commitLink, and generalized the idempotency guard regex (bulletLinkRE) to recognize both [[PR]] and [[commit]] links so re-runs leave existing links untouched.
- changelog/git.go: added Commit.commitLink(repo), which uses the locally-found SHA (Commit.Id()).
- changelog/changelog_test.go: added tests for CommitURL and the commit-link idempotency case.

closes [NIT-4981](https://linear.app/offchain-labs/issue/NIT-4981/add-option-to-exclude-pr-links-from-unclog-release-command)